### PR TITLE
Add Equal and Not Equal tests for Tuples with null fields.

### DIFF
--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -97,8 +97,16 @@
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 2, Name : null }</expression>
 			<output>false</output>
 		</test>
-		<test name="TupleEqJohn1John2WithBothNamesNull">
+		<test name="TupleEqDifferentNamesWithOneNullId">
+			<expression>Tuple { Id : null, Name : 'John' } = Tuple { Id : 1, Name : 'James' }</expression>
+			<output>false</output>
+		</test>
+		<test name="TupleEqJohn1John1WithBothNamesNull">
 			<expression>Tuple { Id : 1, Name : null } = Tuple { Id : 1, Name : null }</expression>
+			<output>true</output>
+		</test>
+		<test name="TupleEqJohnJohnWithBothIdsNull">
+			<expression>Tuple { Id : null, Name : 'John' } = Tuple { Id : null, Name : 'John' }</expression>
 			<output>true</output>
 		</test>
 		<test name="TupleEqJohn1John1WithNullName">
@@ -779,8 +787,16 @@
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 2, Name : null }</expression>
 			<output>true</output>
 		</test>
+		<test name="TupleNotEqDifferingNamesWithOneNullId">
+			<expression>Tuple{ Id : null, Name : 'John' } != Tuple{ Id : 1, Name : 'Joe' }</expression>
+			<output>true</output>
+		</test>
 		<test name="TupleNotEqJohn1John1WithBothNamesNull">
 			<expression>Tuple{ Id : 1, Name : null } != Tuple{ Id : 1, Name : null }</expression>
+			<output>false</output>
+		</test>
+		<test name="TupleNotEqMatchingNamesWithNullIDs">
+			<expression>Tuple{ Id : null, Name : 'John' } != Tuple{ Id : null, Name : 'John' }</expression>
 			<output>false</output>
 		</test>
 		<test name="TupleNotEqJohn1John1WithNullName">

--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -97,6 +97,10 @@
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 2, Name : null }</expression>
 			<output>false</output>
 		</test>
+		<test name="TupleEqJohn1John2WithBothNamesNull">
+			<expression>Tuple { Id : 1, Name : null } = Tuple { Id : 1, Name : null }</expression>
+			<output>true</output>
+		</test>
 		<test name="TupleEqJohn1John1WithNullName">
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 1, Name : null }</expression>
 			<output>null</output>
@@ -774,6 +778,10 @@
 		<test name="TupleNotEqJohn1John2WithNullName">
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 2, Name : null }</expression>
 			<output>true</output>
+		</test>
+		<test name="TupleNotEqJohn1John1WithBothNamesNull">
+			<expression>Tuple{ Id : 1, Name : null } != Tuple{ Id : 1, Name : null }</expression>
+			<output>false</output>
 		</test>
 		<test name="TupleNotEqJohn1John1WithNullName">
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 1, Name : null }</expression>

--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -93,7 +93,11 @@
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 2, Name : 'John' }</expression>
 			<output>false</output>
 		</test>
-		<test name="TupleEqMissingFieldIsNull">
+		<test name="TupleEqJohn1John2WithNullName">
+			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 2, Name : null }</expression>
+			<output>false</output>
+		</test>
+		<test name="TupleEqJohn1John1WithNullName">
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 1, Name : null }</expression>
 			<output>null</output>
 		</test>
@@ -767,7 +771,11 @@
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 2, Name : 'John' }</expression>
 			<output>true</output>
 		</test>
-		<test name="TupleNotEqMissingFieldIsNull">
+		<test name="TupleNotEqJohn1John2WithNullName">
+			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 2, Name : null }</expression>
+			<output>true</output>
+		</test>
+		<test name="TupleNotEqJohn1John1WithNullName">
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 1, Name : null }</expression>
 			<output>null</output>
 		</test>

--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -93,6 +93,10 @@
 			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 2, Name : 'John' }</expression>
 			<output>false</output>
 		</test>
+		<test name="TupleEqMissingFieldIsNull">
+			<expression>Tuple { Id : 1, Name : 'John' } = Tuple { Id : 1, Name : null }</expression>
+			<output>null</output>
+		</test>
 		<test name="TupleEqDateTimeTrue">
 			<expression>Tuple { dateId: 1, Date: DateTime(2012, 10, 5, 0, 0, 0, 0) } = Tuple { dateId: 1, Date: DateTime(2012, 10, 5, 0, 0, 0, 0) }</expression>
 			<output>true</output>
@@ -762,6 +766,10 @@
 		<test name="TupleNotEqJohn1John2">
 			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 2, Name : 'John' }</expression>
 			<output>true</output>
+		</test>
+		<test name="TupleNotEqMissingFieldIsNull">
+			<expression>Tuple{ Id : 1, Name : 'John' } != Tuple{ Id : 1, Name : null }</expression>
+			<output>null</output>
 		</test>
 		<test name="DateTimeNotEqTodayToday">
 			<expression>Today() != Today()</expression>


### PR DESCRIPTION
This change adds equal and not equal tests for Tuples that have missing values, based on clarifications and discussions in the [Zulip Chat](https://chat.fhir.org/#narrow/stream/179220-cql/topic/NotEquivalent.20ELM.20representation/near/425401720).

We may wish to make a change to add cases like this for Equivalent and Not Equivalent too, but I limited this PR to the discussion at hand.

__Questions__:
* We don't yet have any CI for these tests yet, so what testing or validation do we wish to do with these before submitting? I have manually run these in the Java engine successfully (except for ones where Bryn said the Java behavior is incorrect). 
* I wasn't sure about the test naming convention, so took a random stab at it.