### PR TITLE
Update XSD to allow 0 tests in a group.

### DIFF
--- a/tests/testSchema.xsd
+++ b/tests/testSchema.xsd
@@ -42,7 +42,7 @@
 					<xs:documentation>Notes about the test group.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="test" type="Test" maxOccurs="unbounded"/>
+			<xs:element name="test" type="Test" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="name" type="xs:string">
 			<xs:annotation>


### PR DESCRIPTION
We need to update the XSD to allow no tests in a group. Here is an [example](https://github.com/cqframework/cql-tests/blob/a0762b904431db68be6c02f928ace87d010e0ce2/tests/cql/ValueLiteralsAndSelectors.xml#L317) of a test with a group without tests. Not doing this causes these validation failures: https://github.com/cqframework/cql-tests/actions/runs/9164545728/job/25196067658?pr=21 in the PR to autovalidate XML in our repo (#21).

Alternatively, we can remove these placeholder groups.