### PR TITLE
Adding edge case tests for overlaps operators.

### DIFF
--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -1016,6 +1016,14 @@
 			<expression>Interval[1, 10] overlaps Interval[4, 10]</expression>
 			<output>true</output>
 		</test>
+		<test name="IntegerIntervalOverlapsTrue2">
+			<expression>Interval[4, 10] overlaps Interval[4, 10]</expression>
+			<output>true</output>
+		</test>
+		<test name="IntegerIntervalOverlapsTrue3">
+			<expression>Interval[10, 15] overlaps Interval[4, 10]</expression>
+			<output>true</output>
+		</test>
 		<test name="IntegerIntervalOverlapsFalse">
 			<expression>Interval[1, 10] overlaps Interval[11, 20]</expression>
 			<output>false</output>
@@ -1066,6 +1074,10 @@
 			<expression>Interval[4, 10] overlaps before Interval[1, 10]</expression>
 			<output>false</output>
 		</test>
+		<test name="IntegerIntervalOverlapsBeforeFalse2">
+			<expression>Interval[4, 10] overlaps before Interval[4, 10]</expression>
+			<output>false</output>
+		</test>
 		<test name="DecimalIntervalOverlapsBeforeTrue">
 			<expression>Interval[1.0, 10.0] overlaps before Interval[4.0, 10.0]</expression>
 			<output>true</output>
@@ -1110,6 +1122,10 @@
 		</test>
 		<test name="IntegerIntervalOverlapsAfterFalse">
 			<expression>Interval[4, 10] overlaps after Interval[1, 10]</expression>
+			<output>false</output>
+		</test>
+		<test name="IntegerIntervalOverlapsAfterFalse2">
+			<expression>Interval[4, 10] overlaps after Interval[4, 10]</expression>
 			<output>false</output>
 		</test>
 		<test name="DecimalIntervalOverlapsAfterTrue">


### PR DESCRIPTION
This adds a few edge case tests for the overlaps, overlaps before and overlaps after operators. These tests are related to the technical correction submitted to the specification here:

https://jira.hl7.org/browse/FHIR-46051

The author's guide is unclear about the intended interpretation of "overlaps before" and "overlaps after", whereas the reference and logical specification are both clear. These tests cover the edges of:

1) overlaps for equal intervals (true)
2) overlaps where the first interval starts at the end of the second (true)
3) overlaps before for equal intervals (false)
4) overlaps after for equal intervals (false)