### PR TITLE
Fix Combine test with empty list.

### DIFF
--- a/tests/cql/CqlStringOperatorsTest.xml
+++ b/tests/cql/CqlStringOperatorsTest.xml
@@ -8,7 +8,7 @@
 		</test>
 		<test name="CombineEmptyList">
 			<expression>Combine({})</expression>
-			<output>''</output>
+			<output>null</output>
 		</test>
 		<test name="CombineABC">
 			<expression>Combine({'a', 'b', 'c'})</expression>


### PR DESCRIPTION
The spec says:

"If either argument is null, __or the source list is empty__, the result is null."

https://cql.hl7.org/09-b-cqlreference.html#combine