### PR TITLE
Fix expected output for the EqualNullNull test

### DIFF
--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -129,7 +129,7 @@
 	<group name="Equal">
 		<test name="EqualNullNull">
 			<expression>{null} = {null}</expression>
-			<output>null</output>
+			<output>true</output>
 		</test>
 		<test name="EqualEmptyListNull">
 			<expression>{} as List&lt;String&gt; = null</expression>


### PR DESCRIPTION
The logical specification ([link](https://cql.hl7.org/04-logicalspecification.html#equal)) says:

> For list types, this means that equality returns true if and only if the lists contain elements of the same type, have the same number of elements, and for each element in the lists, in order, the elements are equal using equality semantics, with the exception that null elements are considered equal.

This PR changes the expected result for the `{null} = {null}` expression to `true`.

Looks like this was also raised at Connectathon 36 ([link to wiki](https://github.com/cqframework/cql-tests/wiki/Connectathon-36#equalnullnull)).