### PR TITLE
Update ValueSet Type Testing to use System.ValueSet

### DIFF
--- a/tests/cql/CqlTypeOperatorsTest.xml
+++ b/tests/cql/CqlTypeOperatorsTest.xml
@@ -51,7 +51,7 @@
 			<output>false</output>
 		</test>
 		<test name="ValueSetIsVocabulary">
-			<expression>ValueSet{id: id { value: '123'}} is Vocabulary</expression>
+			<expression>System.ValueSet{id: '123'} is Vocabulary</expression>
 			<output>true</output>
 			<notes>This should return true because ValueSet is derived from Vocabulary.</notes>
 		</test>


### PR DESCRIPTION
This explicitly uses the System.ValueSet instead of the FHIR ValueSet instance construction, which is what was used earlier (incorrectly). In practice, we don't really _need_ to qualify with System since no FHIR data model is included, so I can remove that if we'd like. In the case a FHIR data model _was_ included, the System qualifier would be needed based on [this thread](https://chat.fhir.org/#narrow/stream/179220-cql/topic/Resolving.20the.20name.20Quantity).

Thanks @evan-gordon for noticing that this doesn't parse in our engine!