### PR TITLE
Add aggregate function tests. Use CVL for expected output.

### DIFF
--- a/tests/cql/CqlAggregateFunctionsTest.xml
+++ b/tests/cql/CqlAggregateFunctionsTest.xml
@@ -84,7 +84,7 @@
 		</test>
 	</group>
 	<group name="Product">
-		<test name="Product_Long">
+		<test name="ProductLong">
 			<expression>Product({5L, 4L, 5L})</expression>
 			<output>100L</output>
 		</test>

--- a/tests/cql/CqlAggregateFunctionsTest.xml
+++ b/tests/cql/CqlAggregateFunctionsTest.xml
@@ -30,6 +30,10 @@
 			<expression>AllTrue({})</expression>
 			<output>true</output>
 		</test>
+		<test name="AllTrueIsTrueWhenNull">
+			<expression>AllTrue(null)</expression>
+			<output>true</output>
+		</test>
 	</group>
 	<group name="AnyTrue">
 		<test name="AnyTrueAllTrue">
@@ -68,11 +72,21 @@
 			<expression>AnyTrue({})</expression>
 			<output>false</output>
 		</test>
+		<test name="AnyTrueIsFalseWhenNull">
+			<expression>AnyTrue(null)</expression>
+			<output>false</output>
+		</test>
 	</group>
 	<group name="Avg">
 		<test name="AvgTest1">
 			<expression>Avg({ 1.0, 2.0, 3.0, 6.0 })</expression>
 			<output>3.0</output>
+		</test>
+	</group>
+	<group name="Product">
+		<test name="Product_Long">
+			<expression>Product({5L, 4L, 5L})</expression>
+			<output>100L</output>
 		</test>
 	</group>
 	<group name="Count">
@@ -98,13 +112,17 @@
 			<expression>Max({ 5, 12, 1, 15, 0, 4, 90, 44 })</expression>
 			<output>90</output>
 		</test>
+		<test name="MaxTestLong">
+			<expression>Max({ 5L, 12L, 1L, 15L, 0L, 4L, 90L, 44L })</expression>
+			<output>90L</output>
+		</test>
 		<test name="MaxTestString">
 			<expression>Max({ 'hi', 'bye', 'zebra' })</expression>
 			<output>'zebra'</output>
 		</test>
 		<test name="MaxTestDateTime">
 			<expression>Max({ DateTime(2012, 10, 5), DateTime(2012, 9, 5), DateTime(2012, 10, 6) })</expression>
-			<output>DateTime(2012, 10, 6)</output>
+			<output>@2012-10-06T</output>
 		</test>
 		<test name="MaxTestTime">
 			<expression>Max({ @T15:59:59.999, @T05:59:59.999, @T20:59:59.999 })</expression>
@@ -122,13 +140,17 @@
 			<expression>Min({5, 12, 1, 15, 0, 4, 90, 44})</expression>
 			<output>0</output>
 		</test>
+		<test name="MinTestLong">
+			<expression>Min({5L, 12L, 1L, 15L, 0L, 4L, 90L, 44L})</expression>
+			<output>0L</output>
+		</test>
 		<test name="MinTestString">
 			<expression>Min({'hi', 'bye', 'zebra'})</expression>
 			<output>'bye'</output>
 		</test>
 		<test name="MinTestDateTime">
 			<expression>Min({ DateTime(2012, 10, 5), DateTime(2012, 9, 5), DateTime(2012, 10, 6) })</expression>
-			<output>DateTime(2012, 9, 5)</output>
+			<output>@2012-09-05T</output>
 		</test>
 		<test name="MinTestTime">
 			<expression>Min({ @T15:59:59.999, @T05:59:59.999, @T20:59:59.999 })</expression>
@@ -142,7 +164,11 @@
 		</test>
 		<test name="ModeTestDateTime">
 			<expression>Mode({ DateTime(2012, 10, 5), DateTime(2012, 9, 5), DateTime(2012, 10, 6), DateTime(2012, 9, 5) })</expression>
-			<output>DateTime(2012, 9, 5)</output>
+			<output>@2012-09-05T</output>
+		</test>
+		<test name="ModeTestDateTime2">
+			<expression>Mode({ DateTime(2012, 10, 5), DateTime(2012, 10, 5), DateTime(2012, 10, 6), DateTime(2012, 9, 5) })</expression>
+			<output>@2012-10-05T</output>
 		</test>
 		<test name="ModeTestTime">
 			<expression>Mode({ @T15:59:59.999, @T05:59:59.999, @T20:59:59.999, @T05:59:59.999 })</expression>
@@ -155,11 +181,19 @@
 			<output>1.41421356</output>
 			<!-- 23730951454746218587388284504413604736328125 -->
 		</test>
+		<test name="PopulationStdDevIsNull">
+			<expression>PopulationStdDev({ null as Quantity, null as Quantity, null as Quantity })</expression>
+			<output>null</output>
+		</test>
 	</group>
 	<group name="PopulationVariance">
 		<test name="PopVarianceTest1">
 			<expression>PopulationVariance({ 1.0, 2.0, 3.0, 4.0, 5.0 })</expression>
 			<output>2.0</output>
+		</test>
+		<test name="PopVarianceIsNull">
+			<expression>PopulationVariance({ null as Quantity, null as Quantity, null as Quantity })</expression>
+			<output>null</output>
 		</test>
 	</group>
 	<group name="StdDev">
@@ -168,11 +202,23 @@
 			<output>1.58113883</output>
 			<!-- 00841897613935316257993690669536590576171875 -->
 		</test>
+		<test name="StdDevIsNull">
+			<expression>StdDev({ null as Quantity, null as Quantity, null as Quantity })</expression>
+			<output>null</output>
+		</test>
 	</group>
 	<group name="Sum">
 		<test name="SumTest1">
 			<expression>Sum({ 6.0, 2.0, 3.0, 4.0, 5.0 })</expression>
 			<output>20.0</output>
+		</test>
+		<test name="SumTestLong">
+			<expression>Sum({ 6L, 2L, 3L, 4L, 5L })</expression>
+			<output>20L</output>
+		</test>
+		<test name="SumTestQuantity">
+			<expression>Sum({1 'ml',2 'ml',3 'ml',4 'ml',5 'ml'})</expression>
+			<output>15 'ml'</output>
 		</test>
 		<test name="SumTestNull">
 			<expression>Sum({ null, 1, null })</expression>


### PR DESCRIPTION
This PR adds new conformance tests for aggregate functions. I picked all the ones from https://github.com/cqframework/clinical_quality_language/blob/7e91478/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlAggregateFunctionsTest.cql which didn't exist yet here.

Using CVL (literals only) for the expected output values, building on top of https://github.com/cqframework/cql-tests/pull/29. Focusing only on the `tests/cql/CqlAggregateFunctionsTest.xml` tests.