### PR TITLE
Add arithmetic function tests

### DIFF
--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -237,14 +237,6 @@
 			<expression>HighBoundary(@T10:30, 9)</expression>
 			<output>@T10:30:59.999</output>
 		</test>
-		<test name="HighBoundaryNull">
-			<expression>HighBoundary(null as Decimal, 8)</expression>
-			<output>null</output>
-		</test>
-		<test name="HighBoundaryNullPrecision">
-			<expression>HighBoundary(1.58888, null)</expression>
-			<output>1.58888999</output>
-		</test>
 	</group>
 	<group name="Log">
 		<test name="LogNullNull">
@@ -300,14 +292,6 @@
 		<test name="LowBoundaryTimeMillisecond">
 			<expression>LowBoundary(@T10:30, 9)</expression>
 			<output>@T10:30:00.000</output>
-		</test>
-		<test name="LowBoundaryNull">
-			<expression>LowBoundary(null as Decimal, 8)</expression>
-			<output>null</output>
-		</test>
-		<test name="LowBoundaryNullPrecision">
-			<expression>LowBoundary(1.58888, null)</expression>
-			<output>1.58888000</output>
 		</test>
 	</group>
 	<group name="Ln">

--- a/tests/cql/CqlArithmeticFunctionsTest.xml
+++ b/tests/cql/CqlArithmeticFunctionsTest.xml
@@ -40,6 +40,10 @@
 			<expression>1 + 1</expression>
 			<output>2</output>
 		</test>
+		<test name="Add1L2L">
+			<expression>1L + 2L</expression>
+			<output>3L</output>
+		</test>
 		<test name="Add1D1D">
 			<expression>1.0 + 1.0</expression>
 			<output>2.0</output>
@@ -102,6 +106,10 @@
 		</test>
 		<test name="Divide11">
 			<expression>1 / 1</expression>
+			<output>1.0</output>
+		</test>
+		<test name="Divide1L1L">
+			<expression>1L / 1L</expression>
 			<output>1.0</output>
 		</test>
 		<test name="Divide1d1d">
@@ -195,6 +203,10 @@
 			<expression>Round(Exp(1), 8)</expression>
 			<output>2.71828183</output>
 		</test>
+		<test name="Exp1L">
+			<expression>Round(Exp(1L), 8)</expression>
+			<output>2.71828183</output>
+		</test>
 		<test name="ExpNeg1">
 			<expression>Round(Exp(-1), 8)</expression>
 			<output>0.36787944</output>
@@ -225,6 +237,14 @@
 			<expression>HighBoundary(@T10:30, 9)</expression>
 			<output>@T10:30:59.999</output>
 		</test>
+		<test name="HighBoundaryNull">
+			<expression>HighBoundary(null as Decimal, 8)</expression>
+			<output>null</output>
+		</test>
+		<test name="HighBoundaryNullPrecision">
+			<expression>HighBoundary(1.58888, null)</expression>
+			<output>1.58888999</output>
+		</test>
 	</group>
 	<group name="Log">
 		<test name="LogNullNull">
@@ -239,12 +259,20 @@
 			<expression>Log(1, 1)</expression>
 			<output>null</output>
 		</test>
+		<test name="Log2Base1">
+			<expression>Log(2, 1)</expression>
+			<output>null</output>
+		</test>
 		<test name="Log1Base2">
 			<expression>Log(1, 2)</expression>
 			<output>0.0</output>
 		</test>
 		<test name="Log1Base100">
 			<expression>Log(1, 100)</expression>
+			<output>0.0</output>
+		</test>
+		<test name="Log1Base100L">
+			<expression>Log(1L, 100L)</expression>
 			<output>0.0</output>
 		</test>
 		<test name="Log16Base2">
@@ -273,6 +301,14 @@
 			<expression>LowBoundary(@T10:30, 9)</expression>
 			<output>@T10:30:00.000</output>
 		</test>
+		<test name="LowBoundaryNull">
+			<expression>LowBoundary(null as Decimal, 8)</expression>
+			<output>null</output>
+		</test>
+		<test name="LowBoundaryNullPrecision">
+			<expression>LowBoundary(1.58888, null)</expression>
+			<output>1.58888000</output>
+		</test>
 	</group>
 	<group name="Ln">
 		<test name="LnNull">
@@ -289,6 +325,10 @@
 		</test>
 		<test name="Ln1">
 			<expression>Ln(1)</expression>
+			<output>0.0</output>
+		</test>
+		<test name="Ln1L">
+			<expression>Ln(1L)</expression>
 			<output>0.0</output>
 		</test>
 		<test name="LnNeg1">
@@ -400,6 +440,14 @@
 			<expression>3.5 'cm' mod 3 'cm'</expression>
 			<output>0.5 'cm'</output>
 		</test>
+		<test name="Modulo10By3Quantity">
+			<expression>10.0 'g' mod 3.0 'g'</expression>
+			<output>1.0 'g'</output>
+		</test>
+		<test name="Modulo10By0Quantity">
+			<expression>10.0 'g' mod 0.0 'g'</expression>
+			<output>null</output>
+		</test>
 	</group>
 	<group name="Multiply">
 		<test name="MultiplyNull">
@@ -409,6 +457,10 @@
 		<test name="Multiply1By1">
 			<expression>1 * 1</expression>
 			<output>1</output>
+		</test>
+		<test name="Multiply2LBy3L">
+			<expression>2L * 3L</expression>
+			<output>6L</output>
 		</test>
 		<test name="Multiply1DBy2D">
 			<expression>1.0 * 2.0</expression>
@@ -444,6 +496,14 @@
 		<test name="Negate1">
 			<expression>-1</expression>
 			<output>-1</output>
+		</test>
+		<test name="Negate1L">
+			<expression>-1L</expression>
+			<output>-1L</output>
+		</test>
+		<test name="NegateMaxLong">
+			<expression>-9223372036854775807L</expression>
+			<output>-9223372036854775807L</output>
 		</test>
 		<test name="NegateNeg1">
 			<expression>-(-1)</expression>
@@ -590,6 +650,10 @@
 		<test name="Power2To4">
 			<expression>2^4</expression>
 			<output>16</output>
+		</test>
+		<test name="Power2LTo3L">
+			<expression>2L^3L</expression>
+			<output>8L</output>
 		</test>
 		<test name="Power2DTo4D">
 			<expression>2.0^4.0</expression>
@@ -828,6 +892,18 @@
 		<test name="TruncatedDivide10d1ByNeg3D1Quantity">
 			<expression>10.1 'cm' div -3.1 'cm'</expression>
 			<output>-3.0 'cm'</output>
+		</test>
+		<test name="TruncatedDivide10By5DQuantity">
+			<expression>10.0 'g' div 5.0 'g'</expression>
+			<output>2.0 'g'</output>
+		</test>
+		<test name="TruncatedDivide414By206DQuantity">
+			<expression>4.14 'm' div 2.06 'm'</expression>
+			<output>2.0 'm'</output>
+		</test>
+		<test name="TruncatedDivide10By0DQuantity">
+			<expression>10.0 'g' div 0.0 'g'</expression>
+			<output>null</output>
 		</test>
 	</group>
 </tests>


### PR DESCRIPTION
This PR adds new conformance tests for arithmetic functions. I picked all the ones from https://github.com/cqframework/clinical_quality_language/blob/7e91478/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlArithmeticFunctionsTest.cql which didn't exist yet here.

Using CVL (literals only) for the expected output values.

This is independent from https://github.com/cqframework/cql-tests/pull/33.