### PR TITLE
Add aggregate query tests

### DIFF
--- a/tests/cql/CqlAggregateTest.xml
+++ b/tests/cql/CqlAggregateTest.xml
@@ -1,21 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
-  name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
+	name="CqlAggregateTest" reference="http://build.fhir.org/ig/HL7/cql/03-developersguide.html#aggregate-queries">
 	<group name="AggregateTests">
 		<test name="FactorialOfFive">
 			<expression>({ 1, 2, 3, 4, 5 }) Num aggregate Result starting 1: Result * Num</expression>
 			<output>120</output>
 		</test>
-    <test name="RolledOutIntervals">
-      <expression>MedicationRequestIntervals M
-    aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
-      M X
-        let S: Max({ end of Last(R) + 1 day, start of X }),
-          E: S + duration in days of X
-        return Interval[S, E]
-    })</expression>
-      <output>TODO</output>
-      <!-- Translation Error: Could not resolve identifier MedicationRequestIntervals in the current library. -->
-    </test>
-  </group>
+		<test name="RolledOutIntervals">
+			<expression>
+				({
+				  Interval[@2012-01-01, @2012-02-28],
+				  Interval[@2012-02-01, @2012-03-31],
+				  Interval[@2012-03-01, @2012-04-30]
+				}) M
+				  aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
+				    M X
+				      let S: Max({ end of Last(R) + 1 day, start of X }),
+				        E: S + duration in days of X
+				      return Interval[S, E]
+				  })
+			</expression>
+			<output>
+				{
+				  Interval[@2012-01-01, @2012-02-28],
+				  Interval[@2012-02-29, @2012-04-28],
+				  Interval[@2012-04-29, @2012-06-28]
+				}
+			</output>
+			<!-- Execution Error: Invalid precision: 1. -->
+		</test>
+		<test name="AggregateSumWithStart">
+			<expression>
+				({ 1, 2, 3, 4, 5 }) Num
+				  aggregate Result starting 1: Result + Num
+			</expression>
+			<output>16</output>
+			<!-- 15 + 1 (the initial value) -->
+		</test>
+		<test name="AggregateSumWithNull">
+			<expression>
+				({ 1, 2, 3, 4, 5 }) Num
+				  aggregate Result: Coalesce(Result, 0) + Num
+			</expression>
+			<output>15</output>
+			<!-- 15 + 0 (the initial value from null) -->
+		</test>
+		<test name="AggregateSumAll">
+			<expression>
+				({ 1, 1, 2, 2, 2, 3, 4, 4, 5 }) Num
+				  aggregate all Result: Coalesce(Result, 0) + Num
+			</expression>
+			<output>24</output>
+			<!-- 24 + 0 -->
+		</test>
+		<test name="AggregateSumDistinct">
+			<expression>
+				({ 1, 1, 2, 2, 2, 3, 4, 4, 5 }) Num
+				  aggregate distinct Result: Coalesce(Result, 0) + Num
+			</expression>
+			<output>15</output>
+			<!-- 15 + 0 (the initial value) -->
+		</test>
+		<test name="Multi">
+			<expression>
+				from ({1}) X, ({2}) Y, ({3}) Z
+				  aggregate Agg: Coalesce(Agg, 0) + X + Y + Z
+			</expression>
+			<output>6</output>
+		</test>
+		<test name="MegaMulti">
+			<expression>
+				from ({1, 2}) X, ({1, 2}) Y, ({1, 2}) Z
+				  aggregate Agg starting 0: Agg + X + Y + Z
+			</expression>
+			<output>36</output>
+			<!-- (1+1+1)+(1+1+2)+(1+2+1)+(1+2+2)+(2+1+1)+(2+1+2)+(2+2+1)+(2+2+2) -->
+		</test>
+		<test name="MegaMultiDistinct">
+			<expression>
+				from ({1, 2, 2, 1}) X, ({1, 2, 1, 2}) Y, ({2, 1, 2, 1}) Z
+				  aggregate distinct Agg starting 1: Agg + X + Y + Z
+			</expression>
+			<output>37</output>
+			<!-- 1 + (1+1+1)+(1+1+2)+(1+2+1)+(1+2+2)+(2+1+1)+(2+1+2)+(2+2+1)+(2+2+2) -->
+		</test>
+	</group>
 </tests>


### PR DESCRIPTION
This PR adds new conformance tests for aggregate queries. I picked all the ones from https://github.com/cqframework/clinical_quality_language/blob/7e91478/Src/java/engine/src/test/resources/org/opencds/cqf/cql/engine/execution/CqlAggregateQueryTest.cql which didn't exist yet here.

Using CVL (literals only) for the expected output values.

This builds on top of https://github.com/cqframework/cql-tests/pull/32.