### PR TITLE
Add list equality tests

### DIFF
--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -143,6 +143,26 @@
 			<expression>{} = {}</expression>
 			<output>true</output>
 		</test>
+		<test name="EqualABCAndABC">
+			<expression>{ 'a', 'b', 'c' } = { 'a', 'b', 'c' }</expression>
+			<output>true</output>
+		</test>
+		<test name="EqualABCAndAB">
+			<expression>{ 'a', 'b', 'c' } = { 'a', 'b' }</expression>
+			<output>false</output>
+		</test>
+		<test name="EqualABCAnd123">
+			<expression>{ 'a', 'b', 'c' } = { 1, 2, 3 }</expression>
+			<output>false</output>
+		</test>
+		<test name="Equal123AndABC">
+			<expression>{ 1, 2, 3 } = { 'a', 'b', 'c' }</expression>
+			<output>false</output>
+		</test>
+		<test name="Equal123AndString123">
+			<expression>{ 1, 2, 3 } = { '1', '2', '3' }</expression>
+			<output>false</output>
+		</test>
 		<test name="Equal12And123">
 			<expression>{ 1, 2 } = { 1, 2, 3 }</expression>
 			<output>false</output>


### PR DESCRIPTION
This PR adds new conformance tests for list equality. I picked all the ones from https://github.com/cqframework/clinical_quality_language/blob/dfafdb9/Src/java/cql-to-elm/src/test/resources/org/cqframework/cql/cql2elm/OperatorTests/CqlComparisonOperators.cql which didn't exist yet here.