### PR TITLE
Add tests for ProperContains and ProperIn

### DIFF
--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -847,18 +847,22 @@
 	<group name="ProperContains" version="1.0">
 		<capability code="list-operators" />
 		<test name="ProperContains1" version="1.0">
+			<capability code="list-operators" />
 			<expression>null as List&lt;String&gt; properly includes 'a'</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperContains2" version="1.0">
+			<capability code="list-operators" />
 			<expression>{} properly includes 'a'</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperContains3" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ 'a' } properly includes 'a'</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperContains4" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ null } properly includes null as String</expression>
 			<output>false</output>
 		</test>
@@ -868,12 +872,38 @@
 			<output>false</output>
 		</test>
 		<test name="ProperContains5" version="1.0">
+			<capability code="list-operators" />
 			<expression>{ null, null } properly includes null as String</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperContainsNullRightTrue" version="1.0">
 			<capability code="list-operators" />
 			<expression>{'s', 'u', 'n', null} properly includes null</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains6" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b' } properly includes 'a'</expression>
+			<output>true</output>
+		</test>
+		<test name="ProperContains7" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'a' } properly includes 'a'</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains8" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b' } properly includes 'c'</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperContains9" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', null } properly includes 'a'</expression>
+			<output>null</output>
+		</test>
+		<test name="ProperContains10" version="1.0">
+			<capability code="list-operators" />
+			<expression>{ 'a', 'b', null } properly includes 'a'</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperContainsTimeTrue" version="1.0">
@@ -889,9 +919,34 @@
 	</group>
 	<group name="ProperIn" version="1.0">
 		<capability code="list-operators" />
+		<test name="ProperIn1" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in null as List&lt;String&gt;</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn2" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in {}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn3" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a' }</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn4" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as String properly included in { null }</expression>
+			<output>false</output>
+		</test>
 		<test name="ProperInNullRightFalse" version="1.0">
 			<capability code="list-operators" />
 			<expression>null properly included in {'s', 'u', 'n'}</expression>
+			<output>false</output>
+		</test>
+		<test name="ProperIn5" version="1.0">
+			<capability code="list-operators" />
+			<expression>null as String properly included in { null, null }</expression>
 			<output>false</output>
 		</test>
 		<test name="ProperInNullRightTrue" version="1.0">
@@ -899,24 +954,29 @@
 			<expression>null properly included in {'s', 'u', 'n', null}</expression>
 			<output>true</output>
 		</test>
-		<test name="ProperContains6" version="1.0">
-			<expression>{ 'a', 'b' } properly includes 'a'</expression>
+		<test name="ProperIn6" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'b' }</expression>
 			<output>true</output>
 		</test>
-		<test name="ProperContains7" version="1.0">
-			<expression>{ 'a', 'a' } properly includes 'a'</expression>
+		<test name="ProperIn7" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'a' }</expression>
 			<output>false</output>
 		</test>
-		<test name="ProperContains8" version="1.0">
-			<expression>{ 'a', 'b' } properly includes 'c'</expression>
+		<test name="ProperIn8" version="1.0">
+			<capability code="list-operators" />
+			<expression>'c' properly included in { 'a', 'b' }</expression>
 			<output>false</output>
 		</test>
-		<test name="ProperContains9" version="1.0">
-			<expression>{ 'a', null } properly includes 'a'</expression>
+		<test name="ProperIn9" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', null }</expression>
 			<output>null</output>
 		</test>
-		<test name="ProperContains10" version="1.0">
-			<expression>{ 'a', 'b', null } properly includes 'a'</expression>
+		<test name="ProperIn10" version="1.0">
+			<capability code="list-operators" />
+			<expression>'a' properly included in { 'a', 'b', null }</expression>
 			<output>true</output>
 		</test>
 		<test name="ProperInTimeTrue" version="1.0">


### PR DESCRIPTION
Adding more tests for [ProperContains](https://cql.hl7.org/04-logicalspecification.html#proper-contains) and [ProperIn](https://cql.hl7.org/04-logicalspecification.html#proper-in) operators to cover more edge cases for the list overload.

Adjusting 4 existing tests to make it clear and make sure that ProperContainsNullRightFalse and ProperContainsNullRightTrue compile to ProperContains(List<T>, T) and that ProperInNullRightFalse and ProperInNullRightTrue compile to ProperIn(T, List<T>), matching the test name/group. Without null as String, the args could be resolved as List<T>, List<T> and compile to ProperIncludes(List<T>, List<T>) and ProperIncludedIn(List<T>, List<T>).

Unfortunately, the original PR (https://github.com/cqframework/cql-tests/pull/40) was closed automatically and cannot be reopened, so I have to open this new one.

Note that there's also an active thread under https://github.com/cqframework/clinical_quality_language/pull/1394.