### PR TITLE
Cast nulls as lists or intervals to avoid ambiguities

### DIFF
--- a/tests/cql/CqlIntervalOperatorsTest.xml
+++ b/tests/cql/CqlIntervalOperatorsTest.xml
@@ -277,7 +277,7 @@
 			<output>null</output>
 		</test>
 		<test name="TestNullElement1">
-			<expression>null contains 5</expression>
+			<expression>null as Interval&lt;Integer&gt; contains 5</expression>
 			<output>false</output>
 		</test>
 		<test name="TestNullElement2">

--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -77,7 +77,7 @@
 			<output>false</output>
 		</test>
 		<test name="ContainsNullLeft">
-			<expression>null contains 'a'</expression>
+			<expression>null as List&lt;String&gt; contains 'a'</expression>
 			<output>false</output>
 		</test>
 	</group>
@@ -306,7 +306,7 @@
 			<output>true</output>
 		</test>
 		<test name="In1Null">
-			<expression>1 in null</expression>
+			<expression>1 in null as List&lt;Integer&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="In1And12">
@@ -372,7 +372,7 @@
 			<output>false</output>
 		</test>
 		<test name="IncludesNullLeft">
-			<expression>null includes {2}</expression>
+			<expression>null as List&lt;Integer&gt; includes {2}</expression>
 			<output>null</output>
 		</test>
 		<!-- this test is going to the ContainsEvaluator -->
@@ -424,7 +424,7 @@
 			<output>null</output>
 		</test>
 		<test name="IncludedInNullRight">
-			<expression>{'s', 'a', 'm'} included in null</expression>
+			<expression>{'s', 'a', 'm'} included in null as List&lt;String&gt;</expression>
 			<output>null</output>
 		</test>
 	</group>


### PR DESCRIPTION
There are a few test cases in which `null`s technically can be resolved as either Lists or Intervals. For example, `null contains 5` can be interpreted as either `Contains(List<Integer>, Integer)` or `Contains(Interval<Integer>, Integer)`.

This PR adds explicit casts to the cases with such ambiguities.