### PR TITLE
Fix for test case MatchesWordsAndSpacesFalse

### DIFF
--- a/tests/cql/CqlStringOperatorsTest.xml
+++ b/tests/cql/CqlStringOperatorsTest.xml
@@ -172,7 +172,7 @@
 			<output>true</output>
 		</test>
 		<test name="MatchesWordsAndSpacesFalse">
-			<expression>Matches('Not all who wander are lost - circa 2017', '[\\w]+')</expression>
+			<expression>Matches('Not all who wander are lost - circa 2017', '^[\\w]+$')</expression>
 			<output>false</output>
 		</test>
 		<test name="MatchesNotWords">


### PR DESCRIPTION
The test case MatchesWordsAndSpacesFalse as currently implemented I believe is incorrect. The current regex string of '[\\w]+' is looking for any partial match of a group of one or more characters, which given the input string of "Not all who wander are lost - circa 2017" is true, as there is a partial match for many of the words of the input string The test as implemented I believe is supposed to look like Matches('Not all who wander are lost - circa 2017', '^[\\w]+$'), as this would call for exact pattern matching not partial, and properly return false.


The documentation on the Clinical Quality Language [Specification ](https://cql.hl7.org/09-b-cqlreference.html#matches) also showcases a test case that has this problem, I just have not found a method for suggesting changes to that resource. 

I could be misinterpreting Matches however, so feel free to let me know if I am off base.