### PR TITLE
Added a substring test case for an empty string and zero index.

### DIFF
--- a/tests/cql/CqlStringOperatorsTest.xml
+++ b/tests/cql/CqlStringOperatorsTest.xml
@@ -301,6 +301,10 @@
 			<expression>Substring('ab', -1)</expression>
 			<output>null</output>
 		</test>
+		<test name="SubstringEmptyAnd0">
+			<expression>Substring('', 0)</expression>
+			<output>''</output>
+		</test>
 		<test name="SubstringAB0To1">
 			<expression>Substring('ab', 0, 1)</expression>
 			<output>'a'</output>


### PR DESCRIPTION
From looking at the docs it was a bit unclear if this case should return empty string or null, but empty string made the most sense to me. Happy to discuss this further.

Related to @suyashkumar 's changes in https://github.com/google/cql/pull/117