### PR TITLE
Fix RolledOutIntervals Test

### DIFF
--- a/tests/cql/CqlAggregateTest.xml
+++ b/tests/cql/CqlAggregateTest.xml
@@ -16,7 +16,7 @@
 				  aggregate R starting (null as List&lt;Interval&lt;DateTime>>): R union ({
 				    M X
 				      let S: Max({ end of Last(R) + 1 day, start of X }),
-				        E: S + duration in days of X
+				        E: S + Quantity{ value: duration in days of X, unit: 'days' }
 				      return Interval[S, E]
 				  })
 			</expression>
@@ -27,7 +27,6 @@
 				  Interval[@2012-04-29, @2012-06-28]
 				}
 			</output>
-			<!-- Execution Error: Invalid precision: 1. -->
 		</test>
 		<test name="AggregateSumWithStart">
 			<expression>


### PR DESCRIPTION
It is not possible to add an integer to a date. This PR updates the RolledOutIntervals test to properly add a time-based quantity instead.