### PR TITLE
changed tests for Integer vs Sting list compares

### DIFF
--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -194,32 +194,32 @@
 		</test>
 		<test name="EqualABCAnd123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 'a', 'b', 'c' } = { 1, 2, 3 }</expression>
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; ~ { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123AndABC" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } = { 'a', 'b', 'c' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123AndString123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } = { '1', '2', '3' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal12And123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2 } = { 1, 2, 3 }</expression>
+			<expression>{ 1, 2 } as List&lt;Any&gt; = { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And12" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } = { 1, 2 }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 1, 2 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } = { 1, 2, 3 }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualDateTimeTrue" version="1.0">
@@ -741,19 +741,19 @@
 		</test>
 		<test name="EquivalentABCAnd123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 'a', 'b', 'c' } ~ { 1, 2, 3 }</expression>
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; ~ { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="Equivalent123AndABC" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } ~ { 'a', 'b', 'c' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; ~ { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="Equivalent123AndString123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } ~ { '1', '2', '3' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; ~ { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>false</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
@@ -807,19 +807,19 @@
 		</test>
 		<test name="NotEqualABCAnd123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 'a', 'b', 'c' } != { 1, 2, 3 }</expression>
+			<expression>{ 'a', 'b', 'c' } as List&lt;Any&gt; != { 1, 2, 3 } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="NotEqual123AndABC" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } != { 'a', 'b', 'c' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; != { 'a', 'b', 'c' } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>
 		<test name="NotEqual123AndString123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } != { '1', '2', '3' }</expression>
+			<expression>{ 1, 2, 3 } as List&lt;Any&gt; != { '1', '2', '3' } as List&lt;Any&gt;</expression>
 			<output>true</output>
 			<!-- TODO: make Translator resolve isolated Equivalent operator signatures -->
 		</test>

--- a/tests/cql/CqlListOperatorsTest.xml
+++ b/tests/cql/CqlListOperatorsTest.xml
@@ -209,17 +209,17 @@
 		</test>
 		<test name="Equal12And123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2 } as List&lt;Any&gt; = { 1, 2, 3 } as List&lt;Any&gt;</expression>
+			<expression>{ 1, 2 } = { 1, 2, 3 }</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And12" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 1, 2 } as List&lt;Any&gt;</expression>
+			<expression>{ 1, 2, 3 } = { 1, 2 }</expression>
 			<output>false</output>
 		</test>
 		<test name="Equal123And123" version="1.0">
 			<capability code="list-operators" />
-			<expression>{ 1, 2, 3 } as List&lt;Any&gt; = { 1, 2, 3 } as List&lt;Any&gt;</expression>
+			<expression>{ 1, 2, 3 } = { 1, 2, 3 }</expression>
 			<output>true</output>
 		</test>
 		<test name="EqualDateTimeTrue" version="1.0">


### PR DESCRIPTION
This is a fix for https://github.com/cqframework/clinical_quality_language/issues/1720#issue-4196123262 "Equivalence operation returning EvaluationError in several instances"

Added  as List&lt;Any&gt; to expressions to clarify lists. Fixed the error that was occurring: "EvaluationError:Library expression-1.0.0 loaded, but had errors: Could not resolve call to operator Equivalent with signature (list<System.Integer>, list<System.String>)."

Changes those tests from fail to pass.