### PR TITLE
adjustments to expected output in several comparator operators

### DIFF
--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -132,7 +132,7 @@
 		<test name="TupleEqDifferentNamesWithOneNullId" version="1.5">
 			<capability code="tuple"/>
 			<expression>Tuple { Id : null, Name : 'John' } = Tuple { Id : 1, Name : 'James' }</expression>
-			<output>false</output>
+			<output>null</output>
 		</test>
 		<test name="TupleEqJohn1John1WithBothNamesNull" version="1.5">
 			<capability code="tuple"/>
@@ -744,11 +744,11 @@
 		</test>
 		<test name="EquivFloat1Float1WithPrecision" version="1.0">
 			<expression>1.5 ~ 1.55</expression>
-			<output>true</output>
+			<output>false</output>
 		</test>
 		<test name="EquivFloat1Float1WithPrecisionAndZ" version="1.0">
 			<expression>1.50 ~ 1.55</expression>
-			<output>true</output>
+			<output>false</output>
 		</test>
 		<test name="EquivFloatTrailingZero" version="1.0">
 			<expression>1.001 ~ 1.000</expression>
@@ -929,7 +929,7 @@
 		<test name="TupleNotEqDifferingNamesWithOneNullId" version="1.5">
 			<capability code="tuple"/>
 			<expression>Tuple{ Id : null, Name : 'John' } != Tuple{ Id : 1, Name : 'Joe' }</expression>
-			<output>true</output>
+			<output>null</output>
 		</test>
 		<test name="TupleNotEqJohn1John1WithBothNamesNull" version="1.5">
 			<capability code="tuple"/>
@@ -1100,7 +1100,7 @@
 		</test>
 		<test name="TestMonthEquivalentDays" version="1.0">
 			<expression>1 month ~ 30 days</expression>
-			<output>true</output>
+			<output>false</output>
 		</test>
 		<test name="TestWeekEqualDays" version="1.0">
 			<expression>1 week = 7 days</expression>

--- a/tests/cql/CqlComparisonOperatorsTest.xml
+++ b/tests/cql/CqlComparisonOperatorsTest.xml
@@ -1100,7 +1100,7 @@
 		</test>
 		<test name="TestMonthEquivalentDays" version="1.0">
 			<expression>1 month ~ 30 days</expression>
-			<output>false</output>
+			<output>true</output>
 		</test>
 		<test name="TestWeekEqualDays" version="1.0">
 			<expression>1 week = 7 days</expression>


### PR DESCRIPTION
These tests were adjusted:

TupleEqDifferentNamesWithOneNullId
EquivFloat1Float1WithPrecision
EquivFloat1Float1WithPrecisionAndZ
TupleNotEqDifferingNamesWithOneNullId
TestMonthEquivalentDays