### PR TITLE
adjusted CodeToConcept1 to correct test in CqlTypeOperatorsTest

### DIFF
--- a/tests/cql/CqlTypeOperatorsTest.xml
+++ b/tests/cql/CqlTypeOperatorsTest.xml
@@ -85,12 +85,7 @@
 		<test name="CodeToConcept1" version="1.0">
 			<capability code="type-operators" />
 			<expression>ToConcept(Code { code: '8480-6' })</expression>
-			<output>
-				Concept {
-					codes: Code { code: '8480-6' }
-				}
-			</output>
-		</test>
+			<output>Concept { codes: { Code { code: '8480-6' } } }</output>		</test>
 	</group>
 	<group name="ToDateTime" version="1.0">
 		<capability code="type-operators" />


### PR DESCRIPTION
Goes along with PR https://github.com/cqframework/cql-tests-runner/pull/100

to duplicate run 
```
<?xml version="1.0" encoding="utf-8"?>
<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
       name="CqlTypeOperatorsTest">
	<group name="SingleTest" version="1.0">
		<test name="CodeToConcept1" version="1.0">
			<capability code="type-operators" />
			<expression>ToConcept(Code { code: '8480-6' })</expression>
			<output>Concept { codes: { Code { code: '8480-6' } } }</output>
		</test>
	</group>
</tests>
```