### PR TITLE
Add a test for leap year

### DIFF
--- a/tests/cql/CqlDateTimeOperatorsTest.xml
+++ b/tests/cql/CqlDateTimeOperatorsTest.xml
@@ -821,6 +821,16 @@
 			<expression>years between DateTime(2005, 5) and DateTime(2010, 4)</expression>
 			<output>4</output>
 		</test>
+		<test name="YearsBetweenLeapYears1" version="1.4">
+			<capability code="duration-between"/>
+			<expression>years between @2012-02-29 and @2014-02-28</expression>
+			<output>2</output>
+		</test>
+		<test name="YearsBetweenLeapYears2" version="1.4">
+			<capability code="duration-between"/>
+			<expression>years between @2012-02-29T12:34:56 and @2014-02-28T12:34:56</expression>
+			<output>2</output>
+		</test>
 		<test name="DateTimeDurationBetweenMonth" version="1.4">
 		  	<capability code="duration-between"/>
 			<expression>months between @2014-01-31 and @2014-02-01</expression>


### PR DESCRIPTION
Closes #105.

When calculating duration in years between dates, if both dates fall on the last day of February, the expected result is (see https://cql.hl7.org/15-h-timeintervalcalculations.html#scenario-4):

```
Duration (years) = year (date 2) - year (date 1)
```