### PR TITLE
ToTime2, 3, & 4 should expect null values

### DIFF
--- a/tests/cql/CqlTypeOperatorsTest.xml
+++ b/tests/cql/CqlTypeOperatorsTest.xml
@@ -197,17 +197,17 @@
 		<test name="ToTime2" version="1.4">
 			<capability code="type-operators" />
 			<expression>ToTime('T14:30:00.0+05:30')</expression>
-			<output>@T14:30:00.000</output>
+			<output>null</output>
 		</test>
 		<test name="ToTime3" version="1.4">
 			<capability code="type-operators" />
 			<expression>ToTime('T14:30:00.0-05:45')</expression>
-			<output>@T14:30:00.000</output>
+			<output>null</output>
 		</test>
 		<test name="ToTime4" version="1.4">
 			<capability code="type-operators" />
 			<expression>ToTime('T14:30:00.0Z')</expression>
-			<output>@T14:30:00.000</output>
+			<output>null</output>
 		</test>
 		<test name="ToTimeMalformed" version="1.4">
 			<capability code="type-operators" />


### PR DESCRIPTION
Based on the spec ToTime returns null when the expression contains an invalid time string. See:
[cqlreference](https://cql.hl7.org/09-b-cqlreference.html#time)
"CQL supports time values in the range @T00:00:00.0 to @T23:59:59.999 with a step size of 1 millisecond."
&
[logical spec](https://cql.hl7.org/04-logicalspecification.html#totime)
"For String values, the operator expects the string to be formatted using ISO-8601 time representation" and
"If the input string is not formatted correctly, or does not represent a valid time-of-day value, the result is null."